### PR TITLE
allow to lazy load resource list file

### DIFF
--- a/tests/test_Lockable.py
+++ b/tests/test_Lockable.py
@@ -20,6 +20,12 @@ class LockableTests(TestCase):
                 fp.write('[]')
             Lockable(hostname='myhost', resource_list_file=list_file, lock_folder=tmpdirname)
 
+    def test_lock_require_resources_json_loaded(self):
+        lockable = Lockable()
+        with self.assertRaises(AssertionError) as error:
+            lockable.lock({})
+        self.assertEqual(str(error.exception), 'resources list is not loaded')
+
     def test_constructor_file_not_found(self):
         with TemporaryDirectory() as tmpdirname:
             list_file = os.path.join(tmpdirname, 'test.json')


### PR DESCRIPTION
New API to load resources list file after constructor:
```
Lockable:load_resources_list(filename: str)
```

Changes: `Lockable` constructor:
* `resources_list_file` argument is now optional and default values is not `None`. User have to define it always or lazy load it!