### PR TITLE
Allocation context

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Resource is released in following cases:
 * process ends
 * when context ends when `lockable.auto_lock(..)` is used
 * allocation.unlock() is called
-* lockable.unlock(<resource>) is called
+* lockable.unlock(<allocation>) is called
 
 # API's
 
@@ -27,7 +27,7 @@ print(allocation.resource_info)
 print(allocation.resource_id)
 allocation.unlock()
 # or using resource info
-lockable.unlock(allocation.resource_info)
+lockable.unlock(allocation)
 ```
 
 or using context manager which unlock automatically

--- a/README.md
+++ b/README.md
@@ -32,6 +32,6 @@ lockable.unlock(allocation.resource_info)
 
 or using context manager which unlock automatically
 ```python
-with lockable.auto_lock(requirements, [timeout_s]) as resource_info:
-    print(resource_info)
+with lockable.auto_lock(requirements, [timeout_s]) as allocation:
+    print(allocation.resource_info)
 ```

--- a/lockable/cli.py
+++ b/lockable/cli.py
@@ -49,7 +49,8 @@ def main():
     lockable = Lockable(hostname=args.hostname,
                         resource_list_file=args.resources,
                         lock_folder=args.lock_folder)
-    with lockable.auto_lock(args.requirements, timeout_s=args.timeout) as resource:
+    with lockable.auto_lock(args.requirements, timeout_s=args.timeout) as allocation:
+        resource = allocation.resource_info
         env = os.environ.copy()
         for key in resource.keys():
             env[key.upper()] = str(resource.get(key))

--- a/lockable/lockable.py
+++ b/lockable/lockable.py
@@ -34,6 +34,7 @@ class Allocation:
         return self.resource_info['id']
 
     def release(self, alloc_id):
+        """ Release resource """
         assert self.alloc_id == alloc_id, 'Allocation id mismatch'
         self._release()
         self.alloc_id = None
@@ -102,7 +103,7 @@ class Lockable:
             raise ValueError(f"Invalid json, duplicate ids in {duplicates}")
 
     @staticmethod
-    def parse_requirements(requirements_str: (str or dict)):
+    def parse_requirements(requirements_str: (str or dict)) -> dict:
         """ Parse requirements """
         if not requirements_str:
             return dict()
@@ -208,11 +209,11 @@ class Lockable:
         self.logger.debug("Use lock folder: %s", self._lock_folder)
         self.logger.debug("Requirements: %s", json.dumps(predicate))
         self.logger.debug("Resource list: %s", json.dumps(self._resource_list))
-        reservation = self._lock(predicate, timeout_s)
-        self._allocations[reservation.resource_id] = reservation
-        return reservation
+        allocation = self._lock(predicate, timeout_s)
+        self._allocations[allocation.resource_id] = allocation
+        return allocation
 
-    def unlock(self, allocation: Allocation):
+    def unlock(self, allocation: Allocation) -> None:
         """
         Method to release resource
         :param allocation: Allocation object.

--- a/lockable/lockable.py
+++ b/lockable/lockable.py
@@ -151,7 +151,7 @@ class Lockable:
             return Allocation(requirements=requirements,
                               resource_info=candidate,
                               _release=release,
-                              pid_file=pid_file)
+                              pid_file=_lockable.filename)
         except PidFileError as error:
             raise AssertionError('no success') from error
 

--- a/tests/test_Lockable.py
+++ b/tests/test_Lockable.py
@@ -130,6 +130,7 @@ class LockableTests(TestCase):
 
             with self.assertRaises(ResourceNotFound):
                 alloc = dataclasses.replace(allocation)
+                alloc.resource_info = alloc.resource_info.copy()
                 alloc.resource_info['id'] = '2'
                 lockable.unlock(alloc)
 


### PR DESCRIPTION
NOTE: This introduce breaking change


Originally locking methods returns only resource_info but it was sometimes useful to have access to other allocation related informations so decide to return whole allocation context.

Locking methods (`lock()` and `auto_lock()`) returns now `Allocation` -object that holds all details:
original requirements, resource info, pid_file, release method, allocation begin time.
