### PR TITLE
Introduce HttpProvider

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[report]
+exclude_lines =
+    pragma: no cover
+    @abstract

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,6 @@
 [report]
 exclude_lines =
+    # Have to re-enable the standard pragma
     pragma: no cover
-    @abstract
+
+    @abstractmethod

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Resource is released in following cases:
 * allocation.unlock() is called
 * lockable.unlock(<allocation>) is called
 
+Resources data provider support following mechanisms:
+* `resources.json` file in file system
+* python list of dictionaries
+* http uri which points to API and is used with HTTP GET method. API should provide `resources.json` data as json object.
+
 # CLI interface
 
 ```
@@ -52,7 +57,7 @@ optional arguments:
 
 Constructor
 ```python
-lockable = Lockable([hostname], [resource_list_file], [lock_folder])
+lockable = Lockable([hostname], [resource_list_file], [resource_list], [lock_folder])
 ```
 
 Allocation

--- a/lockable/Provider.py
+++ b/lockable/Provider.py
@@ -97,7 +97,6 @@ class ProviderFile(Provider):
 
     def reload_resource_list_file(self):
         """ Reload resources from file if file has been modified """
-
         mtime = os.path.getmtime(self._uri)
         if self._resource_list_file_mtime != mtime:
             self._resource_list_file_mtime = mtime

--- a/lockable/Provider.py
+++ b/lockable/Provider.py
@@ -1,0 +1,146 @@
+from abc import ABC, abstractmethod
+import json
+import os
+import logging
+import requests
+from urllib.parse import urlparse
+from requests.exceptions import HTTPError
+from pydash import filter_, count_by
+
+MODULE_LOGGER = logging.getLogger('lockable')
+
+
+class ProviderError(Exception):
+    pass
+
+
+class Provider(ABC):
+    def __init__(self, uri: (str, list)):
+        self._uri = uri
+        self._resources = list()
+
+    @property
+    def data(self):
+        self._reload()
+        return self._resources
+
+    @staticmethod
+    def create(uri):
+        """
+        Create provider instance from uri
+        :param uri: list of string for provider
+        :return: Provider object
+        :rtype: Provider
+        """
+        if Provider.is_http_url(uri):
+            return ProviderHttp(uri)
+        elif isinstance(uri, str):
+            return ProviderFile(uri)
+        elif isinstance(uri, list):
+            return ProviderList(uri)
+        raise AssertionError('uri should be list or string')
+
+    @staticmethod
+    def is_http_url(uri):
+        try:
+            result = urlparse(uri)
+            return all([result.scheme, result.netloc])
+        except:
+            return False
+
+    @abstractmethod
+    def _reload(self):
+        pass
+
+    def set_resources_list(self, resources_list: list):
+        """ Load resources list """
+        assert isinstance(resources_list, list), 'resources_list is not an list'
+        self._validate_json(resources_list)
+        self._resources = resources_list
+        MODULE_LOGGER.debug('Resources loaded: ')
+        for resource in self._resources:
+            MODULE_LOGGER.debug(json.dumps(resource))
+
+    @staticmethod
+    def _validate_json(data):
+        """ Internal method to validate resources.json content """
+        counts = count_by(data, lambda obj: obj.get('id'))
+        no_ids = filter_(counts.keys(), lambda key: key is None)
+        if no_ids:
+            raise ValueError('Invalid json, id property is missing')
+
+        duplicates = filter_(counts.keys(), lambda key: counts[key] > 1)
+        if duplicates:
+            MODULE_LOGGER.warning('Duplicates: %s', duplicates)
+            raise ValueError(f"Invalid json, duplicate ids in {duplicates}")
+
+
+class ProviderList(Provider):
+    def __init__(self, uri):
+        super().__init__(uri)
+        self.set_resources_list(self._uri)
+
+    def _reload(self): pass
+
+
+class ProviderFile(Provider):
+
+    def __init__(self, uri):
+        super().__init__(uri)
+        self._resource_list_file_mtime = None
+        self._reload()
+
+    def _reload(self):
+        """ Load resources list file"""
+        self.reload_resource_list_file()
+        MODULE_LOGGER.warning('Use resources from %s file', self._uri)
+
+    def reload_resource_list_file(self):
+        """ Reload resources from file if file has been modified """
+
+        mtime = os.path.getmtime(self._uri)
+        if self._resource_list_file_mtime != mtime:
+            self._resource_list_file_mtime = mtime
+            data = self._read_resources_list_file(self._uri)
+            self.set_resources_list(data)
+
+    @staticmethod
+    def _read_resources_list_file(filename):
+        """ Read resources json file """
+        MODULE_LOGGER.debug('Read resource list file: %s', filename)
+        with open(filename) as json_file:
+            try:
+                data = json.load(json_file)
+                assert isinstance(data, list), 'data is not an list'
+            except (json.decoder.JSONDecodeError, AssertionError) as error:
+                raise ValueError(f'invalid resources json file: {error}') from error
+        return data
+
+
+class ProviderHttp(Provider):
+
+    def __init__(self, uri):
+        super().__init__(uri)
+        self._reload()
+
+    def _reload(self):
+        self.set_resources_list(self._reload_http(self._uri))
+
+    @staticmethod
+    def _reload_http(uri):
+        try:
+            response = requests.get(uri)
+            response.raise_for_status()
+
+            # could utilise ETag or Last-Modified headers to optimize performance
+            # etag = response.headers.get("ETag")
+            # last_modified = response.headers.get("Last-Modified")
+
+            # access JSON content
+            return response.json()
+        except HTTPError as http_err:
+            MODULE_LOGGER.error(f'HTTP error occurred: {http_err}')
+            raise ProviderError(http_err.response.reason) from http_err
+        except Exception as err:
+            MODULE_LOGGER.error(f'Other error occurred: {err}')
+            raise ProviderError(err) from err

--- a/lockable/__init__.py
+++ b/lockable/__init__.py
@@ -1,2 +1,3 @@
 """ Lockable module """
-from lockable.lockable import Lockable, ResourceNotFound, Allocation
+from lockable.lockable import Lockable, ResourceNotFound, Allocation, MODULE_LOGGER
+from lockable.provider import Provider, ProviderError

--- a/lockable/cli.py
+++ b/lockable/cli.py
@@ -65,6 +65,7 @@ def main():
             env[key.upper()] = str(resource.get(key))
         print(json.dumps(env))
         command = ' '.join(args.command)
+        # pylint: disable=consider-using-with
         process = subprocess.Popen(command,
                                    env=env,
                                    shell=True)

--- a/lockable/cli.py
+++ b/lockable/cli.py
@@ -21,7 +21,7 @@ def get_args():
         formatter_class=argparse.RawTextHelpFormatter)
 
     parser.add_argument('--validate-only',
-                        action = "store_true",
+                        action="store_true",
                         default=False,
                         help='Only validate resources.json')
     parser.add_argument('--lock-folder',
@@ -65,7 +65,6 @@ def main():
             env[key.upper()] = str(resource.get(key))
         print(json.dumps(env))
         command = ' '.join(args.command)
-        # pylint: disable=consider-using-with
         process = subprocess.Popen(command,
                                    env=env,
                                    shell=True)

--- a/lockable/cli.py
+++ b/lockable/cli.py
@@ -29,7 +29,7 @@ def get_args():
                         help='lock folder')
     parser.add_argument('--resources',
                         default='./resources.json',
-                        help='Resources file')
+                        help='Resources file or http uri')
     parser.add_argument('--timeout',
                         default=1,
                         help='Timeout for trying allocate suitable resource')

--- a/lockable/lockable.py
+++ b/lockable/lockable.py
@@ -181,6 +181,8 @@ class Lockable:
         assert isinstance(self._resource_list, list), 'resources list is not loaded'
         requirements = self.parse_requirements(requirements)
         predicate = self._get_requirements(requirements, self._hostname)
+        # Refresh resources data
+        self._provider.reload()
         self.logger.debug("Use lock folder: %s", self._lock_folder)
         self.logger.debug("Requirements: %s", json.dumps(predicate))
         self.logger.debug("Resource list: %s", json.dumps(self._resource_list))

--- a/lockable/lockable.py
+++ b/lockable/lockable.py
@@ -64,7 +64,13 @@ class Lockable:
         self.logger.debug('Initialized lockable')
         self._hostname = hostname
         self._lock_folder = lock_folder
-        self._provider = Provider.create(resource_list_file or resource_list)
+        assert not (isinstance(resource_list, list) and
+                    resource_list_file), 'only one of resource_list or ' \
+                                         'resource_list_file is accepted, not both'
+        if resource_list is None and resource_list_file is None:
+            self._provider = Provider.create([])
+        else:
+            self._provider = Provider.create(resource_list_file or resource_list)
 
     @property
     def _resource_list(self):

--- a/lockable/lockable.py
+++ b/lockable/lockable.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 from uuid import uuid1
 from pydash import filter_, merge
 from pid import PidFile, PidFileError
-from lockable.Provider import Provider
+from lockable.provider import Provider
 
 MODULE_LOGGER = logging.getLogger('lockable')
 

--- a/lockable/lockable.py
+++ b/lockable/lockable.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 from uuid import uuid1
 from pydash import filter_, merge
 from pid import PidFile, PidFileError
-from lockable.provider import Provider
+from lockable.provider_helpers import create as create_provider
 
 MODULE_LOGGER = logging.getLogger('lockable')
 
@@ -68,9 +68,9 @@ class Lockable:
                     resource_list_file), 'only one of resource_list or ' \
                                          'resource_list_file is accepted, not both'
         if resource_list is None and resource_list_file is None:
-            self._provider = Provider.create([])
+            self._provider = create_provider([])
         else:
-            self._provider = Provider.create(resource_list_file or resource_list)
+            self._provider = create_provider(resource_list_file or resource_list)
 
     @property
     def _resource_list(self):

--- a/lockable/lockable.py
+++ b/lockable/lockable.py
@@ -10,8 +10,9 @@ from datetime import datetime
 from dataclasses import dataclass
 from contextlib import contextmanager
 from uuid import uuid1
-from pydash import filter_, merge, count_by
+from pydash import filter_, merge
 from pid import PidFile, PidFileError
+from lockable.Provider import Provider
 
 MODULE_LOGGER = logging.getLogger('lockable')
 
@@ -63,68 +64,12 @@ class Lockable:
         self.logger.debug('Initialized lockable')
         self._hostname = hostname
         self._lock_folder = lock_folder
-        self._resource_list = None
-        self._resource_list_file_mtime = None
-        self._resource_list_file = resource_list_file
-        assert not (isinstance(resource_list, list) and
-                    resource_list_file), 'only one of resource_list or ' \
-                                         'resource_list_file is accepted, not both'
-        if isinstance(self._resource_list_file, str):
-            self._resource_list_file_mtime = os.path.getmtime(resource_list_file)
-            self.load_resources_list_file(self._resource_list_file)
-        elif isinstance(resource_list, list):
-            self.load_resources_list(resource_list)
-        else:
-            self.logger.warning('resource_list_file or resource_list is not configured')
+        self._provider = Provider.create(resource_list_file or resource_list)
 
-    def load_resources_list_file(self, filename: str):
-        """ Load resources list file"""
-        self.load_resources_list(self._read_resources_list(filename))
-        self.logger.warning('Use resources from %s file', filename)
+    @property
+    def _resource_list(self):
+        return self._provider.data
 
-    def load_resources_list(self, resources_list: list):
-        """ Load resources list """
-        assert isinstance(resources_list, list), 'resources_list is not an list'
-        self._resource_list = resources_list
-        self.logger.debug('Resources loaded: ')
-        for resource in self._resource_list:
-            self.logger.debug(json.dumps(resource))
-
-    def reload_resource_list_file(self):
-        """ Reload resources from file if file has been modified """
-        if self._resource_list_file_mtime is None:
-            return
-
-        mtime = os.path.getmtime(self._resource_list_file)
-        if self._resource_list_file_mtime != mtime:
-            self._resource_list_file_mtime = mtime
-            self.load_resources_list_file(self._resource_list_file)
-
-    @staticmethod
-    def _read_resources_list(filename):
-        """ Read resources json file """
-        MODULE_LOGGER.debug('Read resource list file: %s', filename)
-        with open(filename) as json_file:
-            try:
-                data = json.load(json_file)
-                assert isinstance(data, list), 'data is not an list'
-            except (json.decoder.JSONDecodeError, AssertionError) as error:
-                raise ValueError(f'invalid resources json file: {error}') from error
-            Lockable._validate_json(data)
-        return data
-
-    @staticmethod
-    def _validate_json(data):
-        """ Internal method to validate resources.json content """
-        counts = count_by(data, lambda obj: obj.get('id'))
-        no_ids = filter_(counts.keys(), lambda key: key is None)
-        if no_ids:
-            raise ValueError('Invalid json, id property is missing')
-
-        duplicates = filter_(counts.keys(), lambda key: counts[key] > 1)
-        if duplicates:
-            MODULE_LOGGER.warning('Duplicates: %s', duplicates)
-            raise ValueError(f"Invalid json, duplicate ids in {duplicates}")
 
     @staticmethod
     def parse_requirements(requirements_str: (str or dict)) -> dict:
@@ -228,7 +173,6 @@ class Lockable:
         :return: Allocation context
         """
         assert isinstance(self._resource_list, list), 'resources list is not loaded'
-        self.reload_resource_list_file()
         requirements = self.parse_requirements(requirements)
         predicate = self._get_requirements(requirements, self._hostname)
         self.logger.debug("Use lock folder: %s", self._lock_folder)

--- a/lockable/provider.py
+++ b/lockable/provider.py
@@ -21,11 +21,11 @@ class Provider(ABC):
         """ Provider constructor """
         self._uri = uri
         self._resources = list()
+        self.reload()
 
     @property
     def data(self) -> list:
         """ Get resources list """
-        self._reload()
         return self._resources
 
     @staticmethod
@@ -38,7 +38,7 @@ class Provider(ABC):
             return False
 
     @abstractmethod
-    def _reload(self) -> None:
+    def reload(self) -> None:
         pass  # pragma: no cover
 
     def set_resources_list(self, resources_list: list):

--- a/lockable/provider.py
+++ b/lockable/provider.py
@@ -18,7 +18,7 @@ class ProviderError(Exception):
 
 class Provider(ABC):
     """ Abstract Provider """
-    def __init__(self, uri: typing.Union[str, list]):
+    def __init__(self, uri: typing.Union[str, List[Dict]]):
         """ Provider constructor """
         self._uri = uri
         self._resources = list()

--- a/lockable/provider.py
+++ b/lockable/provider.py
@@ -1,12 +1,11 @@
 """ Provider library """
 from abc import ABC, abstractmethod
 import json
-import os
-import logging
 import typing
+from typing import List
+import logging
+
 from urllib.parse import urlparse
-import requests
-from requests.exceptions import HTTPError
 from pydash import filter_, count_by
 
 MODULE_LOGGER = logging.getLogger('lockable')
@@ -30,22 +29,6 @@ class Provider(ABC):
         return self._resources
 
     @staticmethod
-    def create(uri):
-        """
-        Create provider instance from uri
-        :param uri: list of string for provider
-        :return: Provider object
-        :rtype: Provider
-        """
-        if Provider.is_http_url(uri):
-            return ProviderHttp(uri)
-        if isinstance(uri, str):
-            return ProviderFile(uri)
-        if isinstance(uri, list):
-            return ProviderList(uri)
-        raise AssertionError('uri should be list or string')
-
-    @staticmethod
     def is_http_url(uri: str) -> bool:
         """ Check if argument is url format"""
         try:
@@ -61,14 +44,14 @@ class Provider(ABC):
     def set_resources_list(self, resources_list: list):
         """ Load resources list """
         assert isinstance(resources_list, list), 'resources_list is not an list'
-        self._validate_json(resources_list)
+        Provider._validate_json(resources_list)
         self._resources = resources_list
         MODULE_LOGGER.debug('Resources loaded: ')
         for resource in self._resources:
             MODULE_LOGGER.debug(json.dumps(resource))
 
     @staticmethod
-    def _validate_json(data):
+    def _validate_json(data: List[dict]):
         """ Internal method to validate resources.json content """
         counts = count_by(data, lambda obj: obj.get('id'))
         no_ids = filter_(counts.keys(), lambda key: key is None)
@@ -79,86 +62,3 @@ class Provider(ABC):
         if duplicates:
             MODULE_LOGGER.warning('Duplicates: %s', duplicates)
             raise ValueError(f"Invalid json, duplicate ids in {duplicates}")
-
-
-class ProviderList(Provider):
-    """ ProviderList implementation """
-
-    def __init__(self, uri):
-        """ ProviderList constructor """
-        super().__init__(uri)
-        self.set_resources_list(self._uri)
-
-    def _reload(self):
-        """ Nothing to do """
-
-
-class ProviderFile(Provider):
-    """ ProviderFile interface """
-
-    def __init__(self, uri):
-        """
-        ProviderFile constructor
-        :param uri: file path
-        """
-        super().__init__(uri)
-        self._resource_list_file_mtime = None
-        self._reload()
-
-    def _reload(self):
-        """ Load resources list file"""
-        self.reload_resource_list_file()
-        MODULE_LOGGER.warning('Use resources from %s file', self._uri)
-
-    def reload_resource_list_file(self):
-        """ Reload resources from file if file has been modified """
-        mtime = os.path.getmtime(self._uri)
-        if self._resource_list_file_mtime != mtime:
-            self._resource_list_file_mtime = mtime
-            data = self._read_resources_list_file(self._uri)
-            self.set_resources_list(data)
-
-    @staticmethod
-    def _read_resources_list_file(filename):
-        """ Read resources json file """
-        MODULE_LOGGER.debug('Read resource list file: %s', filename)
-        with open(filename) as json_file:
-            try:
-                data = json.load(json_file)
-                assert isinstance(data, list), 'data is not an list'
-            except (json.decoder.JSONDecodeError, AssertionError) as error:
-                raise ValueError(f'invalid resources json file: {error}') from error
-        return data
-
-
-class ProviderHttp(Provider):
-    """ ProviderHttp interface"""
-
-    def __init__(self, uri):
-        """ ProviderHttp constructor """
-        super().__init__(uri)
-        self._reload()
-
-    def _reload(self) -> None:
-        """ Reload resources list from web server """
-        self.set_resources_list(self._get_http(self._uri))
-
-    @staticmethod
-    def _get_http(uri) -> list:
-        """ Internal method to get http json data"""
-        try:
-            response = requests.get(uri)
-            response.raise_for_status()
-
-            # could utilise ETag or Last-Modified headers to optimize performance
-            # etag = response.headers.get("ETag")
-            # last_modified = response.headers.get("Last-Modified")
-
-            # access JSON content
-            return response.json()
-        except HTTPError as http_err:
-            MODULE_LOGGER.error('HTTP error occurred %s', http_err)
-            raise ProviderError(http_err.response.reason) from http_err
-        except Exception as err:
-            MODULE_LOGGER.error('Other error occurred: %s', err)
-            raise ProviderError(err) from err

--- a/lockable/provider.py
+++ b/lockable/provider.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 import json
 import os
 import logging
+import typing
 from urllib.parse import urlparse
 import requests
 from requests.exceptions import HTTPError
@@ -17,7 +18,7 @@ class ProviderError(Exception):
 
 class Provider(ABC):
     """ Abstract Provider """
-    def __init__(self, uri: (str, list)):
+    def __init__(self, uri: typing.Union[str, list]):
         """ Provider constructor """
         self._uri = uri
         self._resources = list()

--- a/lockable/provider.py
+++ b/lockable/provider.py
@@ -18,7 +18,7 @@ class ProviderError(Exception):
 
 class Provider(ABC):
     """ Abstract Provider """
-    def __init__(self, uri: typing.Union[str, List[Dict]]):
+    def __init__(self, uri: typing.Union[str, list]):
         """ Provider constructor """
         self._uri = uri
         self._resources = list()

--- a/lockable/provider.py
+++ b/lockable/provider.py
@@ -55,7 +55,7 @@ class Provider(ABC):
 
     @abstractmethod
     def _reload(self) -> None:
-        raise NotImplementedError()
+        pass  # pragma: no cover
 
     def set_resources_list(self, resources_list: list):
         """ Load resources list """

--- a/lockable/provider.py
+++ b/lockable/provider.py
@@ -38,8 +38,8 @@ class Provider(ABC):
             return False
 
     @abstractmethod
-    def reload(self) -> None:
-        pass  # pragma: no cover
+    def reload(self) -> None:  # pragma: no cover
+        """ Reload resources data"""
 
     def set_resources_list(self, resources_list: list):
         """ Load resources list """

--- a/lockable/provider.py
+++ b/lockable/provider.py
@@ -55,7 +55,7 @@ class Provider(ABC):
 
     @abstractmethod
     def _reload(self) -> None:
-        pass
+        raise NotImplementedError()
 
     def set_resources_list(self, resources_list: list):
         """ Load resources list """

--- a/lockable/provider_file.py
+++ b/lockable/provider_file.py
@@ -14,11 +14,10 @@ class ProviderFile(Provider):
         ProviderFile constructor
         :param uri: file path
         """
-        super().__init__(uri)
         self._resource_list_file_mtime = None
-        self._reload()
+        super().__init__(uri)
 
-    def _reload(self):
+    def reload(self):
         """ Load resources list file"""
         self.reload_resource_list_file()
         MODULE_LOGGER.warning('Use resources from %s file', self._uri)

--- a/lockable/provider_file.py
+++ b/lockable/provider_file.py
@@ -1,0 +1,44 @@
+""" resources Provider for file """
+import json
+import os
+from typing import List
+
+from lockable.provider import Provider, MODULE_LOGGER
+
+
+class ProviderFile(Provider):
+    """ ProviderFile interface """
+
+    def __init__(self, uri: str):
+        """
+        ProviderFile constructor
+        :param uri: file path
+        """
+        super().__init__(uri)
+        self._resource_list_file_mtime = None
+        self._reload()
+
+    def _reload(self):
+        """ Load resources list file"""
+        self.reload_resource_list_file()
+        MODULE_LOGGER.warning('Use resources from %s file', self._uri)
+
+    def reload_resource_list_file(self):
+        """ Reload resources from file if file has been modified """
+        mtime = os.path.getmtime(self._uri)
+        if self._resource_list_file_mtime != mtime:
+            self._resource_list_file_mtime = mtime
+            data = self._read_resources_list_file(self._uri)
+            self.set_resources_list(data)
+
+    @staticmethod
+    def _read_resources_list_file(filename: str) -> List[dict]:
+        """ Read resources json file """
+        MODULE_LOGGER.debug('Read resource list file: %s', filename)
+        with open(filename) as json_file:
+            try:
+                data = json.load(json_file)
+                assert isinstance(data, list), 'data is not an list'
+            except (json.decoder.JSONDecodeError, AssertionError) as error:
+                raise ValueError(f'invalid resources json file: {error}') from error
+        return data

--- a/lockable/provider_helpers.py
+++ b/lockable/provider_helpers.py
@@ -1,0 +1,21 @@
+""" resources Provider helper """
+from lockable.provider import Provider
+from lockable.provider_list import ProviderList
+from lockable.provider_file import ProviderFile
+from lockable.provider_http import ProviderHttp
+
+
+def create(uri):
+    """
+    Create provider instance from uri
+    :param uri: list of string for provider
+    :return: Provider object
+    :rtype: Provider
+    """
+    if Provider.is_http_url(uri):
+        return ProviderHttp(uri)
+    if isinstance(uri, str):
+        return ProviderFile(uri)
+    if isinstance(uri, list):
+        return ProviderList(uri)
+    raise AssertionError('uri should be list or string')

--- a/lockable/provider_http.py
+++ b/lockable/provider_http.py
@@ -1,0 +1,41 @@
+""" resources Provider for HTTP """
+import logging
+import requests
+from requests import HTTPError
+
+from lockable.provider import Provider, ProviderError
+
+MODULE_LOGGER = logging.getLogger('lockable')
+
+
+class ProviderHttp(Provider):
+    """ ProviderHttp interface"""
+
+    def __init__(self, uri: str):
+        """ ProviderHttp constructor """
+        super().__init__(uri)
+        self._reload()
+
+    def _reload(self) -> None:
+        """ Reload resources list from web server """
+        self.set_resources_list(self._get_http(self._uri))
+
+    @staticmethod
+    def _get_http(uri: str) -> list:
+        """ Internal method to get http json data"""
+        try:
+            response = requests.get(uri)
+            response.raise_for_status()
+
+            # could utilise ETag or Last-Modified headers to optimize performance
+            # etag = response.headers.get("ETag")
+            # last_modified = response.headers.get("Last-Modified")
+
+            # access JSON content
+            return response.json()
+        except HTTPError as http_err:
+            MODULE_LOGGER.error('HTTP error occurred %s', http_err)
+            raise ProviderError(http_err.response.reason) from http_err
+        except Exception as err:
+            MODULE_LOGGER.error('Other error occurred: %s', err)
+            raise ProviderError(err) from err

--- a/lockable/provider_http.py
+++ b/lockable/provider_http.py
@@ -14,9 +14,8 @@ class ProviderHttp(Provider):
     def __init__(self, uri: str):
         """ ProviderHttp constructor """
         super().__init__(uri)
-        self._reload()
 
-    def _reload(self) -> None:
+    def reload(self) -> None:
         """ Reload resources list from web server """
         self.set_resources_list(self._get_http(self._uri))
 

--- a/lockable/provider_list.py
+++ b/lockable/provider_list.py
@@ -10,5 +10,5 @@ class ProviderList(Provider):
         super().__init__(uri)
         self.set_resources_list(self._uri)
 
-    def _reload(self):
+    def reload(self):
         """ Nothing to do """

--- a/lockable/provider_list.py
+++ b/lockable/provider_list.py
@@ -1,0 +1,14 @@
+""" resources Provider for static list """
+from lockable.provider import Provider
+
+
+class ProviderList(Provider):
+    """ ProviderList implementation """
+
+    def __init__(self, uri: list):
+        """ ProviderList constructor """
+        super().__init__(uri)
+        self.set_resources_list(self._uri)
+
+    def _reload(self):
+        """ Nothing to do """

--- a/lockable/resources.json
+++ b/lockable/resources.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "2",
+    "online": false,
+    "hostname": "localhost",
+    "test": true
+  },
+  {
+    "id": "1",
+    "online": true,
+    "hostname": "localhost",
+    "test": false
+  },
+  {
+    "id": "3",
+    "online": true,
+    "hostname": "localhost2",
+    "test": true
+  }
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+certifi==2021.5.30
+charset-normalizer==2.0.4
+coverage==5.5
+httptest==0.0.17
+idna==3.2
+mock==4.0.3
+pid==3.0.4
+pydash==5.0.0
+requests==2.26.0
+setuptools-scm==6.0.1
+urllib3==1.26.6

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,9 @@ setup(
     },
     install_requires=[
         'pid',
-        'pydash'
+        'pydash',
+        'requests',
+        'httptest'
     ],
     extras_require={
         'dev': ['nose', 'coveralls', 'pylint', 'coverage', 'mock'],

--- a/tests/test_Lockable.py
+++ b/tests/test_Lockable.py
@@ -148,6 +148,7 @@ class LockableTests(TestCase):
             lock_file = os.path.join(lockable._lock_folder, "1.pid")
 
             allocation = lockable.lock({}, timeout_s=0)
+            self.assertIsInstance(allocation, Allocation)
             self.assertTrue(os.path.exists(lock_file))
 
             with self.assertRaises(AssertionError):

--- a/tests/test_Lockable.py
+++ b/tests/test_Lockable.py
@@ -43,14 +43,14 @@ class LockableTests(TestCase):
             lockable = Lockable(hostname='myhost', resource_list_file=list_file, lock_folder=tmpdirname)
             lockable._provider._read_resources_list_file = mock.MagicMock(return_value=[])
             self.assertEqual(lockable._provider._read_resources_list_file.call_count, 0)
-            lockable._provider._reload()
+            lockable._provider.reload()
             self.assertEqual(lockable._provider._read_resources_list_file.call_count, 0)
             with open(list_file, 'w') as fp:
                 fp.write('[1]')
-            lockable._provider._reload()
+            lockable._provider.reload()
             self.assertEqual(lockable._provider._read_resources_list_file.call_count, 1)
             # Check that stored mtime value is updated
-            lockable._provider._reload()
+            lockable._provider.reload()
             self.assertEqual(lockable._provider._read_resources_list_file.call_count, 1)
 
     def test_invalid_constructor(self):

--- a/tests/test_Lockable.py
+++ b/tests/test_Lockable.py
@@ -31,7 +31,7 @@ class LockableTests(TestCase):
             with open(list_file, 'w') as fp:
                 fp.write('[]')
             lockable = Lockable(hostname='myhost', resource_list_file=list_file, lock_folder=tmpdirname)
-            self.assertFalse(lockable._resource_list_file_mtime is None)
+            self.assertFalse(lockable._provider._resource_list_file_mtime is None)
 
     def test_reload_resource_list_file(self):
         with TemporaryDirectory() as tmpdirname:
@@ -41,17 +41,17 @@ class LockableTests(TestCase):
             # mtime has at worst 1 second precision
             time.sleep(1)
             lockable = Lockable(hostname='myhost', resource_list_file=list_file, lock_folder=tmpdirname)
-            lockable.load_resources_list_file = mock.MagicMock()
-            self.assertEqual(lockable.load_resources_list_file.call_count, 0)
-            lockable.reload_resource_list_file()
-            self.assertEqual(lockable.load_resources_list_file.call_count, 0)
+            lockable._provider._read_resources_list_file = mock.MagicMock(return_value=[])
+            self.assertEqual(lockable._provider._read_resources_list_file.call_count, 0)
+            lockable._provider._reload()
+            self.assertEqual(lockable._provider._read_resources_list_file.call_count, 0)
             with open(list_file, 'w') as fp:
                 fp.write('[1]')
-            lockable.reload_resource_list_file()
-            self.assertEqual(lockable.load_resources_list_file.call_count, 1)
+            lockable._provider._reload()
+            self.assertEqual(lockable._provider._read_resources_list_file.call_count, 1)
             # Check that stored mtime value is updated
-            lockable.reload_resource_list_file()
-            self.assertEqual(lockable.load_resources_list_file.call_count, 1)
+            lockable._provider._reload()
+            self.assertEqual(lockable._provider._read_resources_list_file.call_count, 1)
 
     def test_invalid_constructor(self):
         with self.assertRaises(AssertionError):
@@ -60,9 +60,9 @@ class LockableTests(TestCase):
 
     def test_lock_require_resources_json_loaded(self):
         lockable = Lockable()
-        with self.assertRaises(AssertionError) as error:
+        with self.assertRaises(ResourceNotFound) as error:
             lockable.lock({})
-        self.assertEqual(str(error.exception), 'resources list is not loaded')
+        self.assertEqual(str(error.exception), 'Suitable resource not available')
 
     def test_constructor_file_not_found(self):
         with TemporaryDirectory() as tmpdirname:
@@ -127,10 +127,9 @@ class LockableTests(TestCase):
     def test_lock_timeout_0_success(self):
         with create_lockable([{"id": 1, "hostname": "myhost", "online": True}],
                              lock_folder='.') as lockable:
-            lockable.reload_resource_list_file = mock.MagicMock()
+            lockable._provider._read_resources_list_file = mock.MagicMock(return_value=[])
             lock_file = os.path.join(".", "1.pid")
             object = lockable.lock({}, timeout_s=0)
-            self.assertEqual(lockable.reload_resource_list_file.call_count, 1)
             self.assertTrue(os.path.exists(lock_file))
             object.release(object.alloc_id)
             self.assertFalse(os.path.exists(lock_file))

--- a/tests/test_Provider.py
+++ b/tests/test_Provider.py
@@ -1,0 +1,111 @@
+import json
+import logging
+import os
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+from lockable.Provider import Provider, ProviderError, ProviderList, ProviderHttp, ProviderFile
+import httptest
+
+
+class TestHTTPServer200(httptest.Handler):
+
+    def do_GET(self):
+        contents = "[{\"id\": \"abc\"}]".encode()
+        self.send_response(200)
+        self.send_header("ETag", "1234567890")
+        self.send_header("Last-Modified", "Mon, 01 Jan 1970 00:00:00 GMT")
+        self.send_header("Content-type", "text/json")
+        self.send_header("Content-length", len(contents))
+        self.end_headers()
+        self.wfile.write(contents)
+
+
+class TestHTTPServer404(httptest.Handler):
+
+    def do_GET(self):
+        contents = "[{\"id\": \"abc\"}]".encode()
+        self.send_response(404)
+        self.send_header("ETag", "1234567890")
+        self.send_header("Last-Modified", "Mon, 01 Jan 1970 00:00:00 GMT")
+        self.send_header("Content-type", "text/json")
+        self.send_header("Content-length", len(contents))
+        self.end_headers()
+        self.wfile.write(contents)
+
+class TestHTTPServerInvalidData(httptest.Handler):
+
+    def do_GET(self):
+        contents = "oh nou".encode()
+        self.send_response(200)
+        self.send_header("Content-type", "text/plain")
+        self.send_header("Content-length", len(contents))
+        self.end_headers()
+        self.wfile.write(contents)
+
+class ProviderTests(TestCase):
+    def setUp(self) -> None:
+        logger = logging.getLogger('lockable')
+        logger.handlers.clear()
+        logger.addHandler(logging.NullHandler())
+
+    def test_create_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            Provider.create('file')
+        with self.assertRaises(AssertionError):
+            Provider.create(object())
+
+    def test_duplicate_id(self):
+        with TemporaryDirectory() as tmpdirname:
+            list_file = os.path.join(tmpdirname, 'test.json')
+            with open(list_file, 'w') as fp:
+                fp.write('[{"id": "1"}, {"id":  "1"}]')
+            with self.assertRaises(ValueError):
+                Provider.create(list_file)
+
+    def test_create_success(self):
+        self.assertIsInstance(Provider.create([]), ProviderList)
+        with TemporaryDirectory() as tmpdirname:
+            list_file = os.path.join(tmpdirname, 'test.json')
+            with open(list_file, 'w') as fp:
+                fp.write('[]')
+            self.assertIsInstance(Provider.create(list_file), ProviderFile)
+
+    def test_provider_list(self):
+        with self.assertRaises(ValueError):
+            Provider.create([{}])
+        provider = Provider.create([])
+        self.assertEqual(provider.data, [])
+
+    def test_provider_list_set(self):
+        provider = Provider.create([])
+        ref = {"id": "abc"}
+        provider.set_resources_list([ref])
+        self.assertDictEqual(provider.data[0], ref)
+
+    def test_provider_file(self):
+        with TemporaryDirectory() as tmpdirname:
+            list_file = os.path.join(tmpdirname, 'test.json')
+            ref = {"id": "abc"}
+            with open(list_file, 'w') as fp:
+                fp.write(json.dumps([ref]))
+            provider = Provider.create(list_file)
+            self.assertDictEqual(provider.data[0], ref)
+
+    @httptest.Server(TestHTTPServer200)
+    def test_provider_http_success(self, ts=httptest.NoServer()):
+        ts.server_name = 'localhost'
+        provider = Provider.create(ts.url())
+        self.assertEqual(len(provider.data), 1)
+        self.assertDictEqual(provider.data[0], {"id": "abc"})
+
+    @httptest.Server(TestHTTPServer404)
+    def test_provider_http_not_found(self, ts=httptest.NoServer()):
+        ts.server_name = 'localhost'
+        with self.assertRaises(ProviderError):
+            Provider.create(ts.url())
+
+    @httptest.Server(TestHTTPServerInvalidData)
+    def test_provider_http_invalid_data(self, ts=httptest.NoServer()):
+        ts.server_name = 'localhost'
+        with self.assertRaises(ProviderError):
+            Provider.create(ts.url())

--- a/tests/test_Provider.py
+++ b/tests/test_Provider.py
@@ -3,7 +3,7 @@ import logging
 import os
 from tempfile import TemporaryDirectory
 from unittest import TestCase
-from lockable.Provider import Provider, ProviderError, ProviderList, ProviderHttp, ProviderFile
+from lockable.provider import Provider, ProviderError, ProviderList, ProviderHttp, ProviderFile
 import httptest
 
 


### PR DESCRIPTION
Changes:
* extract resources provider from Lockable
  * Provider (abstract)
  * ProviderList  (when resources is given as plain list of objects)
  * ProviderFile (when resources are given as file)
  * ProviderHttp (when resources are given as http url)
* support http resources provider
  * possible to give resources as http url, like http://localhost/resources


Internal changes:
* Lockable._resource_list reload list from file/http and return list of resource objects
* Constructor (re)load resources

TODO:

- [ ] Update readme