### PR TITLE
Allow to allocate regardless online or hostname state

### DIFF
--- a/lockable/lockable.py
+++ b/lockable/lockable.py
@@ -182,7 +182,13 @@ class Lockable:
     def _get_requirements(requirements, hostname):
         """ Generate requirements"""
         MODULE_LOGGER.debug('hostname: %s', hostname)
-        return merge(dict(hostname=hostname, online=True), requirements)
+        merged = merge(dict(hostname=hostname, online=True), requirements)
+        allowed_to_del = ["online", "hostname"]
+        for key in allowed_to_del:
+            # allow to remove online requirement by set it to None
+            if merged[key] is None:
+                del merged[key]
+        return merged
 
     def lock(self, requirements: (str or dict), timeout_s: int = DEFAULT_TIMEOUT) -> Allocation:
         """

--- a/lockable/lockable.py
+++ b/lockable/lockable.py
@@ -172,7 +172,7 @@ class Lockable:
             ResourceNotFound.invariant(resources, "Suitable resource not available")
             local_resources += resources
         # Unique resources by id
-        local_resources = list({v['id']:v for v in local_resources}.values())
+        local_resources = list({v['id']: v for v in local_resources}.values())
         ResourceNotFound.invariant(
             len(local_resources) >= len(requirements), "Suitable resource not available")
         random.shuffle(local_resources)

--- a/tests/test_Lockable.py
+++ b/tests/test_Lockable.py
@@ -49,6 +49,12 @@ class LockableTests(TestCase):
         reqs = Lockable._get_requirements(dict(a=1, online=False), "myhost")
         self.assertEqual(reqs, {"online": False, "a": 1, "hostname": "myhost"})
 
+        reqs = Lockable._get_requirements(dict(a=1, online=None), "myhost")
+        self.assertEqual(reqs, {"a": 1, "hostname": "myhost"})
+
+        reqs = Lockable._get_requirements(dict(a=1, hostname=None), "myhost")
+        self.assertEqual(reqs, {"a": 1, "online": True})
+
     def test_reload_resource_list_file(self):
         with TemporaryDirectory() as tmpdirname:
             list_file = os.path.join(tmpdirname, 'test.json')

--- a/tests/test_Lockable.py
+++ b/tests/test_Lockable.py
@@ -42,6 +42,13 @@ class LockableTests(TestCase):
             lockable = Lockable(hostname='myhost', resource_list_file=list_file, lock_folder=tmpdirname)
             self.assertEqual(lockable.resource_list, [{"id": "123"}])
 
+    def test_get_requirements(self):
+        reqs = Lockable._get_requirements(dict(a=1), "myhost")
+        self.assertEqual(reqs, {"online": True, "a": 1, "hostname": "myhost" })
+
+        reqs = Lockable._get_requirements(dict(a=1, online=False), "myhost")
+        self.assertEqual(reqs, {"online": False, "a": 1, "hostname": "myhost"})
+
     def test_reload_resource_list_file(self):
         with TemporaryDirectory() as tmpdirname:
             list_file = os.path.join(tmpdirname, 'test.json')


### PR DESCRIPTION
This helps maintenance work to allow to allocate devices even it's set as offline