### PR TITLE
allow to allocate using "has_<key>: true".

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,5 +88,6 @@ with lockable.auto_lock(requirements, [timeout_s]) as allocation:
 
 **Tips:**
 
-You can allocate also offline devices by set requirements `"online": None` . 
-You can ignore also `hostname` same same way by  setting it to  None`
+* allocate also offline devices by set requirements `"online": None` . 
+* ignore also `hostname` same way by setting it to `None`
+* use `has_<key>: bool` to check if resource has given key. Useful for optional keys.

--- a/lockable/allocation.py
+++ b/lockable/allocation.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from typing import Union
 from datetime import datetime, timedelta
 
+from pydash import filter_
+
 
 @dataclass
 class Allocation:
@@ -52,3 +54,20 @@ class Allocation:
         """
         end_time = self.release_time or datetime.now()
         return end_time - self.allocation_start_time
+
+    @staticmethod
+    def get_matching_resources(resource_list: [{}], requirements: {}) -> [{}]:
+        """ Get matching resources from resource list """
+        # if there is requirement key "has_xx: <bool>",
+        # make sure resource has that key if bool is True, or not if False
+        # and remove that key from requirements
+        for key, value in requirements.copy().items():
+            if key.startswith('has_'):
+                has_key = key.replace('has_', '')
+                if value:
+                    resource_list = [r for r in resource_list if has_key in r]
+                else:
+                    resource_list = [r for r in resource_list if has_key not in r]
+                requirements.pop(key)
+
+        return filter_(resource_list, requirements)

--- a/lockable/lockable.py
+++ b/lockable/lockable.py
@@ -8,7 +8,7 @@ import socket
 import time
 import tempfile
 
-from pydash import filter_, merge
+from pydash import merge
 from pid import PidFile, PidFileError
 
 from lockable.allocation import Allocation
@@ -163,7 +163,7 @@ class Lockable:
 
     def _lock(self, requirements, timeout_s, retry_interval=1) -> Allocation:
         """ Lock resource """
-        local_resources = filter_(self.resource_list, requirements)
+        local_resources = Allocation.get_matching_resources(self.resource_list, requirements)
         random.shuffle(local_resources)
         ResourceNotFound.invariant(local_resources, "Suitable resource not available")
         return self._lock_some(requirements, local_resources, timeout_s, retry_interval)[0]
@@ -172,7 +172,7 @@ class Lockable:
         """ Lock resource """
         local_resources = []
         for req in requirements:
-            resources = filter_(self.resource_list, req)
+            resources = Allocation.get_matching_resources(self.resource_list, req)
             ResourceNotFound.invariant(resources, "Suitable resource not available")
             local_resources += resources
         # Unique resources by id

--- a/tests/test_allocation.py
+++ b/tests/test_allocation.py
@@ -28,3 +28,24 @@ class LockableTests(TestCase):
                          alloc.release_time - alloc.allocation_start_time)
         self.assertEqual(alloc.allocation_queue_time, None)
         self.assertEqual(str(alloc), 'Allocation(queue_time: None, resource_info: id=1)')
+
+    def test_get_matching_resources_without_has_field(self):
+        resource_list = [{'id': 1, 'name': 'resource1'},
+                         {'id': 2, 'name': 'resource2'}]
+        requirements = {'id': 1}
+        self.assertEqual(Allocation.get_matching_resources(resource_list, requirements),
+                         [resource_list[0]])
+
+    def test_get_matching_resources_with_has_field_true(self):
+        resource_list = [{'id': 1, 'name': 'resource1'},
+                         {'id': 2, 'name': 'resource2', 'field': '1'}]
+        requirements = {'has_field': True}
+        self.assertEqual([resource_list[1]],
+                         Allocation.get_matching_resources(resource_list, requirements))
+
+    def test_get_matching_resources_with_has_field_false(self):
+        resource_list = [{'id': 1, 'name': 'resource1', 'field': '1'},
+                         {'id': 2, 'name': 'resource2'}]
+        requirements = {'has_field': False}
+        self.assertEqual([resource_list[1]],
+                         Allocation.get_matching_resources(resource_list, requirements))


### PR DESCRIPTION
when value is "true”, field has to exists. When false, resources that has key is not accepted.