### PR TITLE
add option to lock using nested objects using flatten object

### DIFF
--- a/lockable/flatten.py
+++ b/lockable/flatten.py
@@ -1,0 +1,23 @@
+def flatten_json(data: dict, parent_key='', sep='.') -> dict:
+    """
+    Flatten a nested dictionary.
+
+    Args:
+    - data (dict): The dictionary to flatten.
+    - parent_key (str, optional): The concatenated key from the parent(s). Defaults to ''.
+    - sep (str, optional): The separator to use between keys. Defaults to '.'.
+
+    Returns:
+    - dict: The flattened dictionary.
+    """
+    items = {}
+    for k, v in data.items():
+        new_key = f"{parent_key}{sep}{k}" if parent_key else k
+        if isinstance(v, dict):
+            items.update(flatten_json(v, new_key, sep=sep))
+        else:
+            items[new_key] = v
+    return items
+
+def flatten_list(array: list) -> list:
+    return list(map(flatten_json, array))

--- a/lockable/provider.py
+++ b/lockable/provider.py
@@ -6,6 +6,7 @@ from typing import List
 
 from pydash import filter_, count_by
 
+from lockable.flatten import flatten_list
 from lockable.logger import get_logger
 
 MODULE_LOGGER = get_logger()
@@ -26,7 +27,7 @@ class Provider(ABC):
     @property
     def data(self) -> list:
         """ Get resources list """
-        return self._resources
+        return flatten_list(self._resources)
 
     @abstractmethod
     def reload(self) -> None:  # pragma: no cover

--- a/tests/test_Lockable.py
+++ b/tests/test_Lockable.py
@@ -274,3 +274,16 @@ class LockableTests(TestCase):
             self.assertTrue(end - start < 2 and end - start > 1)
             self.assertTrue(os.path.exists(os.path.join(tmpdirname, 'a.pid')))
             self.assertFalse(os.path.exists(os.path.join(tmpdirname, 'b.pid')))
+
+    def test_lock_nested(self):
+        with TemporaryDirectory() as tmpdirname:
+            resources = [
+                {"id": "a", "hostname": "myhost", "online": True, "a": 2},
+                {"id": "b", "hostname": "myhost", "online": True, "a": {"b": 2}}
+            ]
+
+            lockable = Lockable(hostname='myhost', resource_list=resources, lock_folder=tmpdirname)
+            resource = lockable.lock({"a.b": 2})
+            self.assertEqual(resource.resource_id, 'b')
+            self.assertEqual(resource.resource_info,
+                {"id": "b", "hostname": "myhost", "online": True, "a.b": 2})

--- a/tests/test_Provider.py
+++ b/tests/test_Provider.py
@@ -163,3 +163,9 @@ class ProviderTests(TestCase):
         ProviderHttp.BACKOFF_FACTOR = 0
         with self.assertRaises(ProviderError):
             create_provider('http://localhost/resource')
+
+    def test_provider_nested_resources(self):
+        nested_resource = {"id": 12, "a": {"b": 2}}
+        flatten_resource = {"a.b": 2, "id": 12}
+        provider = create_provider([nested_resource])
+        self.assertEqual([flatten_resource], provider.data)

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -1,0 +1,36 @@
+import unittest
+
+from lockable.flatten import flatten_json, flatten_list
+
+
+class TestFlattenJson(unittest.TestCase):
+
+    def test_basic_flattening(self):
+        data = {"a": {"b": 1}}
+        result = flatten_json(data)
+        self.assertEqual(result, {"a.b": 1})
+
+    def test_multiple_level_flattening(self):
+        data = {"a": {"b": {"c": 2}}}
+        result = flatten_json(data)
+        self.assertEqual(result, {"a.b.c": 2})
+
+    def test_mixed_flattening(self):
+        data = {"a": {"b": 1, "c": {"d": 2, "e": {"f": 3}}}, "g": 4}
+        result = flatten_json(data)
+        self.assertEqual(result, {'a.b': 1, 'a.c.d': 2, 'a.c.e.f': 3, 'g': 4})
+
+    def test_empty_data(self):
+        data = {}
+        result = flatten_json(data)
+        self.assertEqual(result, {})
+
+    def test_non_nested_data(self):
+        data = {"a": 1, "b": 2}
+        result = flatten_json(data)
+        self.assertEqual(result, data)
+
+    def test_flatten_list_mixed(self):
+        data = [{"a": 1, "b": 2}, {"a": {"b": {"c": 2}}}]
+        result = flatten_list(data)
+        self.assertEqual(result, [{'a': 1, 'b': 2},{ 'a.b.c': 2}])


### PR DESCRIPTION
e.g. resources.json:
```json
[
{"id": "b", "hostname": "myhost", "online": True, "a": {"b": 2}}
]
```

requirements:
```json
{"a.b": 2}
```

or via CLI:  `--requirements a.b=2`