### PR TITLE
allow to use nested requirements in string format

### DIFF
--- a/lockable/lockable.py
+++ b/lockable/lockable.py
@@ -14,6 +14,7 @@ from pid import PidFile, PidFileError
 from lockable.allocation import Allocation
 from lockable.logger import get_logger
 from lockable.provider_helpers import create as create_provider
+from lockable.unflatten import unflatten
 
 MODULE_LOGGER = get_logger()
 DEFAULT_TIMEOUT=1000
@@ -74,7 +75,7 @@ class Lockable:
             elif value.lower() == "false":
                 value = False
             requirements[key] = value
-        return requirements
+        return unflatten(requirements)
 
     @staticmethod
     def parse_requirements(requirements_str: (str or dict)) -> dict:

--- a/lockable/lockable.py
+++ b/lockable/lockable.py
@@ -87,7 +87,9 @@ class Lockable:
         try:
             return json.loads(requirements_str)
         except json.decoder.JSONDecodeError as error:
+            # if the first char is not {, try to parse as string requirements
             if error.colno > 1:
+                # expecting requirements_str to be a json format
                 raise ValueError(str(error)) from error
         return Lockable.parse_str_requirements(requirements_str)
 

--- a/lockable/lockable.py
+++ b/lockable/lockable.py
@@ -57,17 +57,8 @@ class Lockable:
         return self._provider.data
 
     @staticmethod
-    def parse_requirements(requirements_str: (str or dict)) -> dict:
-        """ Parse requirements """
-        if not requirements_str:
-            return {}
-        if isinstance(requirements_str, dict):
-            return requirements_str
-        try:
-            return json.loads(requirements_str)
-        except json.decoder.JSONDecodeError as error:
-            if error.colno > 1:
-                raise ValueError(str(error)) from error
+    def parse_str_requirements(requirements_str: str) -> dict:
+        """ Parse string requirements """
         parts = requirements_str.split('&')
         requirements = {}
         for part in parts:
@@ -84,6 +75,20 @@ class Lockable:
                 value = False
             requirements[key] = value
         return requirements
+
+    @staticmethod
+    def parse_requirements(requirements_str: (str or dict)) -> dict:
+        """ Parse requirements """
+        if not requirements_str:
+            return {}
+        if isinstance(requirements_str, dict):
+            return requirements_str
+        try:
+            return json.loads(requirements_str)
+        except json.decoder.JSONDecodeError as error:
+            if error.colno > 1:
+                raise ValueError(str(error)) from error
+        return Lockable.parse_str_requirements(requirements_str)
 
     def _try_lock(self, requirements, candidate):
         """ Function that tries to lock given candidate resource """

--- a/lockable/unflatten.py
+++ b/lockable/unflatten.py
@@ -1,0 +1,25 @@
+from typing import Any, Dict
+
+
+def unflatten(input_dict: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Convert a flat dictionary with dot-separated keys into a nested dictionary.
+
+    Args:
+        input_dict (Dict[str, Any]): A dictionary with potentially dot-separated keys.
+
+    Returns:
+        Dict[str, Any]: A nested dictionary.
+
+    Example:
+        unflatten({"key": "a", "nested.key": "b"})
+        => {'key': 'a', 'nested': {'key': 'b'}}
+    """
+    result = {}
+    for key, value in input_dict.items():
+        keys = key.split(".")
+        temp = result
+        for k in keys[:-1]:
+            temp = temp.setdefault(k, {})
+        temp[keys[-1]] = value
+    return result

--- a/lockable/unflatten.py
+++ b/lockable/unflatten.py
@@ -20,6 +20,10 @@ def unflatten(input_dict: Dict[str, Any]) -> Dict[str, Any]:
     """
     result = {}
     for key, value in input_dict.items():
+        if not isinstance(key, str):
+            raise ValueError(f"Invalid key type: {type(key)}")
+        if key.startswith('.') or key.endswith('.') or '..' in key:
+            raise ValueError(f"Invalid key format: {key}")
         keys = key.split(".")
         temp = result
         for k in keys[:-1]:

--- a/lockable/unflatten.py
+++ b/lockable/unflatten.py
@@ -1,3 +1,6 @@
+""" Convert a flat dictionary with dot-separated keys into a nested dictionary.
+"""
+
 from typing import Any, Dict
 
 

--- a/tests/test_unflatten.py
+++ b/tests/test_unflatten.py
@@ -28,3 +28,38 @@ class TestUnflatten(unittest.TestCase):
         data = {}
         expected = {}
         self.assertEqual(unflatten(data), expected)
+
+    def test_key_with_only_dot(self):
+        data = {".": "a"}
+        with self.assertRaises(ValueError):  # Assuming you want to raise an error for invalid keys
+            unflatten(data)
+
+    def test_key_ending_with_dot(self):
+        data = {"key.": "a"}
+        with self.assertRaises(ValueError):
+            unflatten(data)
+
+    def test_key_starting_with_dot(self):
+        data = {".key": "a"}
+        with self.assertRaises(ValueError):
+            unflatten(data)
+
+    def test_multiple_consecutive_dots(self):
+        data = {"key1..key2": "a"}
+        with self.assertRaises(ValueError):
+            unflatten(data)
+
+    def test_non_string_keys(self):
+        data = {1: "a"}
+        with self.assertRaises(ValueError):
+            unflatten(data)
+
+    def test_value_as_dict_without_dot_key(self):
+        data = {"key": {"nested": "value"}}
+        expected = {"key": {"nested": "value"}}
+        self.assertEqual(unflatten(data), expected)
+
+    def test_mixed_types(self):
+        data = {"key1": "a", "key2.key3": [1, 2, 3], "key4.key5.key6": {"nested": True}}
+        expected = {"key1": "a", "key2": {"key3": [1, 2, 3]}, "key4": {"key5": {"key6": {"nested": True}}}}
+        self.assertEqual(unflatten(data), expected)

--- a/tests/test_unflatten.py
+++ b/tests/test_unflatten.py
@@ -1,0 +1,30 @@
+import unittest
+from lockable.unflatten import unflatten
+
+
+class TestUnflatten(unittest.TestCase):
+
+    def test_simple_keys(self):
+        data = {"key": "a"}
+        expected = {"key": "a"}
+        self.assertEqual(unflatten(data), expected)
+
+    def test_nested_keys(self):
+        data = {"key": "a", "nested.key": "b"}
+        expected = {'key': 'a', 'nested': {'key': 'b'}}
+        self.assertEqual(unflatten(data), expected)
+
+    def test_multiple_nested_keys(self):
+        data = {"key": "a", "nested.key1": "b", "nested.key2": "c"}
+        expected = {'key': 'a', 'nested': {'key1': 'b', 'key2': 'c'}}
+        self.assertEqual(unflatten(data), expected)
+
+    def test_deeply_nested_keys(self):
+        data = {"key": "a", "nested.level1.level2": "b"}
+        expected = {'key': 'a', 'nested': {'level1': {'level2': 'b'}}}
+        self.assertEqual(unflatten(data), expected)
+
+    def test_empty_dict(self):
+        data = {}
+        expected = {}
+        self.assertEqual(unflatten(data), expected)


### PR DESCRIPTION
allow to use nested requirements in <key>=<value> string format. e.g.

```python
lockable.lock("a.b.c=d")
```