### PR TITLE
handle properly even json requirement was multiple lines

### DIFF
--- a/lockable/lockable.py
+++ b/lockable/lockable.py
@@ -84,12 +84,12 @@ class Lockable:
             return {}
         if isinstance(requirements_str, dict):
             return requirements_str
-        try:
-            return json.loads(requirements_str)
-        except json.decoder.JSONDecodeError as error:
-            # if the first char is not {, try to parse as string requirements
-            if error.pos > 1:
-                # expecting requirements_str to be a json format
+        assert isinstance(requirements_str, str), 'requirements must be string or dict'
+        requirements_str = requirements_str.strip()  # remove leading and trailing spaces
+        if requirements_str.startswith('{'):
+            try:
+                return json.loads(requirements_str)
+            except json.decoder.JSONDecodeError as error:
                 raise ValueError(str(error)) from error
         return Lockable.parse_str_requirements(requirements_str)
 

--- a/lockable/lockable.py
+++ b/lockable/lockable.py
@@ -88,7 +88,7 @@ class Lockable:
             return json.loads(requirements_str)
         except json.decoder.JSONDecodeError as error:
             # if the first char is not {, try to parse as string requirements
-            if error.colno > 1:
+            if error.pos > 1:
                 # expecting requirements_str to be a json format
                 raise ValueError(str(error)) from error
         return Lockable.parse_str_requirements(requirements_str)

--- a/tests/test_Lockable.py
+++ b/tests/test_Lockable.py
@@ -126,6 +126,10 @@ class LockableTests(TestCase):
         self.assertEqual(Lockable.parse_requirements('a=b&c=d'), {"a": "b", "c": "d"})
         self.assertEqual(Lockable.parse_requirements('{"a":"b","c":"d"}'), {"a": "b", "c": "d"})
         with self.assertRaises(ValueError):
+            Lockable.parse_requirements('{')
+        with self.assertRaises(AssertionError):
+            Lockable.parse_requirements(1)
+        with self.assertRaises(ValueError):
             Lockable.parse_requirements('a')
         with self.assertRaises(ValueError):
             Lockable.parse_requirements('a=')

--- a/tests/test_Lockable.py
+++ b/tests/test_Lockable.py
@@ -131,6 +131,8 @@ class LockableTests(TestCase):
             Lockable.parse_requirements('a=')
         with self.assertRaises(ValueError):
             Lockable.parse_requirements('{"a":"b","c":"d}')
+        with self.assertRaises(ValueError):
+            Lockable.parse_requirements('{\na=b}')
 
     def test_lock_resource_not_found(self):
         with create_lockable([]) as lockable:


### PR DESCRIPTION
e.g. this raises now ValueError since json is invalid:
```python
lock("""{
a=b
}""")
```