### PR TITLE
add requirements when suitable resource not found

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,10 +8,6 @@ workflows:
   version: 2
   test:
     jobs:
-      - test-37:
-          filters:
-            tags:
-              only: /.*/
       - test-38:
           filters:
             tags:
@@ -29,7 +25,6 @@ workflows:
             - test-310
             - test-39
             - test-38
-            - test-37
           filters:
             tags:
               only: /^v.*/
@@ -58,9 +53,9 @@ commands:
           key: deps1-{{ .Branch }}-{{ checksum "setup.py" }}
 
 jobs:
-  test-37: &test-template
+  test-38: &test-template
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
     working_directory: ~/lockable
     steps:
       - setup
@@ -85,11 +80,6 @@ jobs:
       - store_artifacts:
           path: junit
           destination: juni
-
-  test-38:
-    <<: *test-template
-    docker:
-    - image: circleci/python:3.8
 
   test-39:
     <<: *test-template

--- a/lockable/lockable.py
+++ b/lockable/lockable.py
@@ -173,7 +173,8 @@ class Lockable:
         """ Lock resource """
         local_resources = filter_(self.resource_list, requirements)
         random.shuffle(local_resources)
-        ResourceNotFound.invariant(local_resources, f"Suitable resource not available, {requirements=}")
+        ResourceNotFound.invariant(local_resources, 
+                                   f"Suitable resource not available, {requirements=}")
         return self._lock_some(requirements, local_resources, timeout_s, retry_interval)[0]
 
     def _lock_many(self, requirements, timeout_s, retry_interval=1) -> [Allocation]:
@@ -181,12 +182,14 @@ class Lockable:
         local_resources = []
         for req in requirements:
             resources = filter_(self.resource_list, req)
-            ResourceNotFound.invariant(resources, f"Suitable resource not available, {requirements=}")
+            ResourceNotFound.invariant(resources, 
+                                       f"Suitable resource not available, {requirements=}")
             local_resources += resources
         # Unique resources by id
         local_resources = list({v['id']: v for v in local_resources}.values())
         ResourceNotFound.invariant(
-            len(local_resources) >= len(requirements), f"Suitable resource not available, {requirements=}")
+            len(local_resources) >= len(requirements), 
+            f"Suitable resource not available, {requirements=}")
         random.shuffle(local_resources)
         return self._lock_some(requirements, local_resources, timeout_s, retry_interval)
 

--- a/lockable/lockable.py
+++ b/lockable/lockable.py
@@ -173,7 +173,7 @@ class Lockable:
         """ Lock resource """
         local_resources = filter_(self.resource_list, requirements)
         random.shuffle(local_resources)
-        ResourceNotFound.invariant(local_resources, "Suitable resource not available")
+        ResourceNotFound.invariant(local_resources, f"Suitable resource not available, {requirements=}")
         return self._lock_some(requirements, local_resources, timeout_s, retry_interval)[0]
 
     def _lock_many(self, requirements, timeout_s, retry_interval=1) -> [Allocation]:
@@ -181,12 +181,12 @@ class Lockable:
         local_resources = []
         for req in requirements:
             resources = filter_(self.resource_list, req)
-            ResourceNotFound.invariant(resources, "Suitable resource not available")
+            ResourceNotFound.invariant(resources, f"Suitable resource not available, {requirements=}")
             local_resources += resources
         # Unique resources by id
         local_resources = list({v['id']: v for v in local_resources}.values())
         ResourceNotFound.invariant(
-            len(local_resources) >= len(requirements), "Suitable resource not available")
+            len(local_resources) >= len(requirements), f"Suitable resource not available, {requirements=}")
         random.shuffle(local_resources)
         return self._lock_some(requirements, local_resources, timeout_s, retry_interval)
 

--- a/lockable/lockable.py
+++ b/lockable/lockable.py
@@ -173,7 +173,7 @@ class Lockable:
         """ Lock resource """
         local_resources = filter_(self.resource_list, requirements)
         random.shuffle(local_resources)
-        ResourceNotFound.invariant(local_resources, 
+        ResourceNotFound.invariant(local_resources,
                                    f"Suitable resource not available, {requirements=}")
         return self._lock_some(requirements, local_resources, timeout_s, retry_interval)[0]
 
@@ -182,13 +182,13 @@ class Lockable:
         local_resources = []
         for req in requirements:
             resources = filter_(self.resource_list, req)
-            ResourceNotFound.invariant(resources, 
+            ResourceNotFound.invariant(resources,
                                        f"Suitable resource not available, {requirements=}")
             local_resources += resources
         # Unique resources by id
         local_resources = list({v['id']: v for v in local_resources}.values())
         ResourceNotFound.invariant(
-            len(local_resources) >= len(requirements), 
+            len(local_resources) >= len(requirements),
             f"Suitable resource not available, {requirements=}")
         random.shuffle(local_resources)
         return self._lock_some(requirements, local_resources, timeout_s, retry_interval)

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     ],
     packages=find_packages(exclude=['tests']),
     keywords="py.test pytest lockable resource",
-    python_requires='>=3.7, <4',
+    python_requires='>=3.8, <4',
     entry_points={
         'console_scripts': [
             'lockable = lockable.cli:main'

--- a/tests/test_Lockable.py
+++ b/tests/test_Lockable.py
@@ -83,7 +83,7 @@ class LockableTests(TestCase):
     def test_lock_require_resources_json_loaded(self):
         lockable = Lockable()
         with self.assertRaises(ResourceNotFound) as error:
-            lockable.lock({"hostname"="test"})
+            lockable.lock({"hostname": "test"})
         self.assertEqual(str(error.exception), "Suitable resource not available, requirements={'hostname': 'test', 'online': True}")
 
     def test_constructor_file_not_found(self):

--- a/tests/test_Lockable.py
+++ b/tests/test_Lockable.py
@@ -83,8 +83,8 @@ class LockableTests(TestCase):
     def test_lock_require_resources_json_loaded(self):
         lockable = Lockable()
         with self.assertRaises(ResourceNotFound) as error:
-            lockable.lock({})
-        self.assertEqual(str(error.exception), 'Suitable resource not available')
+            lockable.lock({"hostname"="test"})
+        self.assertEqual(str(error.exception), "Suitable resource not available, requirements={'hostname': 'test', 'online': True}")
 
     def test_constructor_file_not_found(self):
         with TemporaryDirectory() as tmpdirname:


### PR DESCRIPTION
when suitable device not found, exception is now more declarative:

was:
```
E   lockable.lockable.ResourceNotFound: Suitable resource not available
```

now:
```
E   lockable.lockable.ResourceNotFound: Suitable resource not available, requirements={'hostname': 'test', 'online': True}
```

note: this drops python 3.7 support also!