### PR TITLE
Add group syntax logging for CI

### DIFF
--- a/lockable/lockable.py
+++ b/lockable/lockable.py
@@ -30,6 +30,16 @@ class ResourceNotFound(Exception):
             raise ResourceNotFound(message)
 
 
+def log_with_group(logger, title, message):
+    """ Log message with group syntax if running in GitHub Actions """
+    if os.getenv('CI') == 'true' and os.getenv('GITHUB_ACTIONS') == 'true':
+        print(f"::group::{title}")
+        logger.info(message)
+        print("::endgroup::")
+    else:
+        logger.info(message)
+
+
 class Lockable:
     """
     Base class for Lockable. It handle low-level functionality.

--- a/lockable/provider.py
+++ b/lockable/provider.py
@@ -6,6 +6,7 @@ import typing
 from typing import List
 
 from pydash import filter_, count_by
+from lockable.lockable import log_with_group
 
 MODULE_LOGGER = logging.getLogger(__name__)
 
@@ -36,9 +37,8 @@ class Provider(ABC):
         assert isinstance(resources_list, list), 'resources_list is not an list'
         Provider._validate_json(resources_list)
         self._resources = resources_list
-        MODULE_LOGGER.debug('Resources loaded: ')
-        for resource in self._resources:
-            MODULE_LOGGER.debug(json.dumps(resource))
+        
+        log_with_group(MODULE_LOGGER, 'Resources loaded:', json.dumps(self._resources, indent=2))
 
     @staticmethod
     def _validate_json(data: List[dict]):
@@ -50,5 +50,5 @@ class Provider(ABC):
 
         duplicates = filter_(counts.keys(), lambda key: counts[key] > 1)
         if duplicates:
-            MODULE_LOGGER.warning('Duplicates: %s', duplicates)
+            log_with_group(MODULE_LOGGER, f'Duplicates: {duplicates}')
             raise ValueError(f"Invalid json, duplicate ids in {duplicates}")


### PR DESCRIPTION
group large json prints in GitHub CI

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jupe/py-lockable/pull/228?shareId=227a4130-696b-4bdb-9d21-c4995ded5bff).