### PR TITLE
Add Python 3.12 support and drop 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,10 +8,6 @@ workflows:
   version: 2
   test:
     jobs:
-      - test-38:
-          filters:
-            tags:
-              only: /.*/
       - test-39:
           filters:
             tags:
@@ -20,11 +16,15 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - test-312:
+          filters:
+            tags:
+              only: /.*/
       - deploy:
           requires:
             - test-310
             - test-39
-            - test-38
+            - test-312
           filters:
             tags:
               only: /^v.*/
@@ -53,9 +53,9 @@ commands:
           key: deps1-{{ .Branch }}-{{ checksum "setup.py" }}
 
 jobs:
-  test-38: &test-template
+  test-39: &test-template
     docker:
-      - image: circleci/python:3.8
+      - image: circleci/python:3.9
     working_directory: ~/lockable
     steps:
       - setup
@@ -79,16 +79,16 @@ jobs:
           path: junit
       - store_artifacts:
           path: junit
-          destination: juni
+          destination: junit
 
-  test-39:
-    <<: *test-template
-    docker:
-    - image: circleci/python:3.9
   test-310:
     <<: *test-template
     docker:
-    - image: circleci/python:3.10
+      - image: circleci/python:3.10
+  test-312:
+    <<: *test-template
+    docker:
+      - image: cimg/python:3.12
 
   deploy:
     <<: *test-template

--- a/setup.py
+++ b/setup.py
@@ -37,13 +37,14 @@ setup(
         "Topic :: Software Development :: Testing",
         "Topic :: Utilities",
         'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         "Programming Language :: Python :: 3 :: Only",
     ],
     packages=find_packages(exclude=['tests']),
     keywords="py.test pytest lockable resource",
-    python_requires='>=3.8, <4',
+    python_requires='>=3.9, <4',
     entry_points={
         'console_scripts': [
             'lockable = lockable.cli:main'


### PR DESCRIPTION
## Summary
- add Python 3.12 to supported versions and drop 3.8
- run CI tests and coverage on Python 3.12

## Testing
- `nosetests --with-coverage --cover-package=lockable`

------
https://chatgpt.com/codex/tasks/task_b_68be9b612160833385775a32644c9acb