### PR TITLE
Use setup.py for packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           python --version
+          pip install -U setuptools wheel
           pip install -e .
           pip install -e .[dev]
           pip install -e .[optional]
@@ -59,6 +60,7 @@ jobs:
       - name: Install dependencies
         run: |
           python --version
+          pip install -U setuptools wheel
           pip install -e .
           pip install -e .[dev]
       - name: Build package


### PR DESCRIPTION
## Summary
- remove provisional pyproject.toml
- install setuptools and wheel before building with setup.py

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*
- `pip install -e .[dev]` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*
- `python setup.py sdist` *(fails: No module named 'setuptools')*
- `python setup.py bdist_wheel` *(fails: No module named 'setuptools')*
- `nosetests` *(fails: ModuleNotFoundError: No module named 'mongoquery')*
- `pylint lockable` *(fails: Unable to import 'mongoquery')*


------
https://chatgpt.com/codex/tasks/task_b_68bedb8eba6c8333a71e9396cb2825e1